### PR TITLE
Add client secrets optionally

### DIFF
--- a/apps.schema.json
+++ b/apps.schema.json
@@ -91,6 +91,25 @@
               }
             }
           },
+          "clientSecret": {
+            "type": "object",
+            "title": "clientSecret configuration for the application, a new secret will be created and stored in keyvault if the existing ones with the name are expiring",
+            "required": ["name", "key_vault_name"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "default": "",
+                "title": "Name of the client secret and also the name of the secret to be stored in Azure Key Vault",
+                "examples": ["jenkins-client-secret"]
+              },
+              "key_vault_name": {
+                "type": "string",
+                "default": "",
+                "title": "Azure Key Vault name to store the client secret",
+                "examples": ["my-key-vault"]
+              }
+            }
+          },
           "appRoleAssignments": {
             "type": "array",
             "default": [],

--- a/apps.schema.json
+++ b/apps.schema.json
@@ -93,7 +93,7 @@
           },
           "clientSecret": {
             "type": "object",
-            "title": "clientSecret configuration for the application, a new secret will be created and stored in keyvault if the existing ones with the name are expiring",
+            "title": "clientSecret configuration for the application, a new secret will be created and stored in Key Vault if the existing ones with the name are expiring",
             "required": ["name", "key_vault_name"],
             "properties": {
               "name": {

--- a/apps.yaml
+++ b/apps.yaml
@@ -22,3 +22,6 @@ apps:
       - "User.Read.All"
       - "Group.Read.All"
       - "People.Read"
+    clientSecret:
++     name: test-jenkins
++     key_vault_name: cftsbox-intsvc

--- a/src/application.ts
+++ b/src/application.ts
@@ -1,4 +1,5 @@
 import { SAMLConfig } from "./SAMLConfig.js";
+import { CLIENTSECRET } from "./clientSecret.js";
 import { OnPremisesPublishing } from "./onPremisesPublishing.js";
 import { TLS } from "./tls.js";
 
@@ -13,4 +14,5 @@ export type Application = {
   preferredSingleSignOnMode: string;
   samlConfig: SAMLConfig;
   oauth2Permissions: Array<string>;
+  clientSecret: CLIENTSECRET;
 };

--- a/src/application.ts
+++ b/src/application.ts
@@ -1,5 +1,5 @@
 import { SAMLConfig } from "./SAMLConfig.js";
-import { CLIENTSECRET } from "./clientSecret.js";
+import { ClientSecret } from "./clientSecret.js";
 import { OnPremisesPublishing } from "./onPremisesPublishing.js";
 import { TLS } from "./tls.js";
 
@@ -14,5 +14,5 @@ export type Application = {
   preferredSingleSignOnMode: string;
   samlConfig: SAMLConfig;
   oauth2Permissions: Array<string>;
-  clientSecret: CLIENTSECRET;
+  clientSecret: ClientSecret;
 };

--- a/src/applicationManager.ts
+++ b/src/applicationManager.ts
@@ -9,7 +9,7 @@ import { DefaultAzureCredential } from "@azure/identity";
 import forge from "node-forge";
 import { setPasswordOnPfx } from "./pfx.js";
 import { SAMLConfig } from "./SAMLConfig.js";
-import { CLIENTSECRET } from "./clientSecret.js";
+import { ClientSecret } from "./clientSecret.js";
 import { getDateByAddingDays } from "./utils.js";
 
 export type ApplicationAndServicePrincipalId = {
@@ -382,7 +382,7 @@ export async function addClientSecret({
 }: {
   token: string;
   applicationId: string;
-  clientSecret: CLIENTSECRET;
+  clientSecret: ClientSecret;
 }): Promise<void> {
   if (clientSecret && clientSecret.key_vault_name) {
     const application = await readApplication({ token, applicationId });

--- a/src/clientSecret.ts
+++ b/src/clientSecret.ts
@@ -1,4 +1,4 @@
-export type CLIENTSECRET = {
+export type ClientSecret = {
   name: "string";
   key_vault_name: "string";
 };

--- a/src/clientSecret.ts
+++ b/src/clientSecret.ts
@@ -1,0 +1,4 @@
+export type CLIENTSECRET = {
+  name: "string";
+  key_vault_name: "string";
+};

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -47,6 +47,7 @@ export async function loadApps(configFilePath: string): Promise<Application[]> {
       },
       samlConfig: app.samlConfig,
       oauth2Permissions: app.oauth2Permissions,
+      clientSecret: app.clientSecret,
     };
     return application;
   });

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
   setTLSCertificate,
   updateApplicationConfig,
   addOptionalClaims,
+  addClientSecret,
 } from "./applicationManager.js";
 import { loadApps } from "./configuration.js";
 import {
@@ -106,6 +107,12 @@ for await (const app of apps) {
         token: token,
         objectId: servicePrincipalObjectId,
         oauth2Permissions: app.oauth2Permissions,
+      });
+
+      await addClientSecret({
+        token: token,
+        applicationId: applicationId,
+        clientSecret: app.clientSecret,
       });
     }
 

--- a/src/servicePrincipalManager.ts
+++ b/src/servicePrincipalManager.ts
@@ -1,10 +1,5 @@
 import { errorHandler } from "./errorHandler.js";
-
-const getDateByAddingDays = (days: number) => {
-  const date = new Date();
-  date.setDate(date.getDate() + days);
-  return date;
-};
+import { getDateByAddingDays } from "./utils.js";
 
 export async function setUserAssignmentRequired({
   token,
@@ -231,7 +226,6 @@ export async function enableSaml({
       }),
     }
   );
-
   await errorHandler("Enabling Saml config", result);
 
   await addTokenSigningCertificate({ displayName, token, objectId, appId });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,5 @@
+export const getDateByAddingDays = (days: number) => {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date;
+};


### PR DESCRIPTION
Enabling saml by default adds a client secret, but cannot get the value in response. This option adds a client secret with the name configured and stores the secret value to key vault configured. It will create a new one with same display name when old one is about to expire.  Tested https://portal.azure.com/#@HMCTS.NET/asset/Microsoft_Azure_KeyVault/Secret/https://cftsbox-intsvc.vault.azure.net/secrets/test-jenkins/d7785b3bc81042d492d8fbe7a9d4c9ab 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
