### PR TITLE
Fix pagination issue, check all group role assignments

### DIFF
--- a/src/applicationManager.ts
+++ b/src/applicationManager.ts
@@ -717,7 +717,6 @@ async function disableAppRoles(
   } else {
     return;
   }
-  console.log("Temporarily disabled app roles to allow updates");
 }
 
 /**


### PR DESCRIPTION
An issue was spotted (thanks @MartyFox) where app role group assignments were trying to be created when they already exist leading to an error.
Didn't show up during testing as they were new groups created and had no other role assignments


This is caused by a  shortened response from graph api which didn't include the existing assignment so the code checking for it fell over.
This change parses all the group app role assignment results until a match is found or not, so that none are missed.

Tested this and fixes the current issue

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
