### PR TITLE
Updating functions for role/group assignment to be more specific when searching for the base User group

### DIFF
--- a/apps.yaml
+++ b/apps.yaml
@@ -2,8 +2,6 @@ apps:
   - name: "My app101"
     externalUrl: "https://my-app.app-proxy-poc.sandbox.platform.hmcts.net"
     logoUrl: https://raw.githubusercontent.com/hmcts/azure-app-proxy/main/logos/incident-bot.png
-    appRoleAssignments:
-      - Test app
     internalUrl: "https://my-on-bau101.sandbox.platform.hmcts.net"
     userAssignmentRequired: true
     tls:
@@ -18,6 +16,9 @@ apps:
       optionalClaims:
         - name: "groups"
           additionalProperties: []
+    appRoleAssignments:
+      - Test app
+      - test_group_A
     appRoles:
       - displayName: "A first app role"
         description: "Some description"
@@ -25,6 +26,7 @@ apps:
         id: "aa9aaaaa-2aa8-49aa-954a-a3aaaa08aaa3"
         groups:
           - "test_group_A"
+          - "Test app"
       - displayName: "My second app role"
         description: "Some description"
         value: "testing_again"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-app-proxy-manager",
-  "version": "1.2.10",
+  "version": "SetViaReleaseScript",
   "type": "module",
   "main": "index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-app-proxy-manager",
-  "version": "SetViaReleaseScript",
+  "version": "1.2.10",
   "type": "module",
   "main": "index.js",
   "license": "MIT",

--- a/src/applicationManager.test.ts
+++ b/src/applicationManager.test.ts
@@ -203,7 +203,7 @@ describe("applicationManager", () => {
         objectId: appDetails.servicePrincipalObjectId,
         appRoleId: testAppRoleId,
       }),
-    ).toEqual(true);
+    ).toBeTruthy();
     expect(application.groupMembershipClaims).toEqual("SecurityGroup");
     expect(application.optionalClaims.saml2Token[0].name).toEqual("groups");
 

--- a/src/applicationManager.test.ts
+++ b/src/applicationManager.test.ts
@@ -19,11 +19,12 @@ import { DefaultAzureCredential } from "@azure/identity";
 import { expect, describe, test, beforeAll, afterEach } from "vitest";
 import { defaultOnPremisesFlags } from "./configuration";
 import {
-  assignGroups,
+  assignUserRoleToGroups,
   readServicePrincipal,
   setUserAssignmentRequired,
   isAppRoleAssignedToGroup,
   getEntraGroupId,
+  getAppRoleId,
 } from "./servicePrincipalManager";
 import * as process from "process";
 
@@ -147,7 +148,8 @@ describe("applicationManager", () => {
       objectId: appDetails.servicePrincipalObjectId,
       assignmentRequired: false,
     });
-    await assignGroups({
+
+    await assignUserRoleToGroups({
       token,
       objectId: appDetails.servicePrincipalObjectId,
       groups: [groupNameForRoleAssignments],
@@ -187,12 +189,19 @@ describe("applicationManager", () => {
       applicationId: appDetails.applicationId,
     });
 
+    let testAppRoleId = await getAppRoleId({
+      token,
+      objectId: appDetails.servicePrincipalObjectId,
+      displayName: application.appRoles[0].displayName,
+    }); // Find app role id
+
     expect(application.appRoles[0].displayName).toEqual("Some name");
     expect(
       await isAppRoleAssignedToGroup({
         token,
         groupId: groupId,
         objectId: appDetails.servicePrincipalObjectId,
+        appRoleId: testAppRoleId,
       }),
     ).toEqual(true);
     expect(application.groupMembershipClaims).toEqual("SecurityGroup");

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,7 @@ import {
 } from "./applicationManager.js";
 import { loadApps } from "./configuration.js";
 import {
-  assignGroups,
+  assignUserRoleToGroups,
   setUserAssignmentRequired,
   enableSaml,
 } from "./servicePrincipalManager.js";
@@ -82,7 +82,8 @@ for await (const app of apps) {
       objectId: servicePrincipalObjectId,
       assignmentRequired: app.appRoleAssignmentRequired,
     });
-    await assignGroups({
+
+    await assignUserRoleToGroups({
       token,
       objectId: servicePrincipalObjectId,
       groups: app.appRoleAssignments,

--- a/src/servicePrincipalManager.ts
+++ b/src/servicePrincipalManager.ts
@@ -146,7 +146,8 @@ export async function isAppRoleAssignedToGroup({
   await errorHandler("Checking if app role is already assigned", result);
 
   const body = await result.json();
-  var appRole = body.value.find((element: any) => element.appRoleId === appRoleId) || false;
+  var appRole =
+    body.value.find((element: any) => element.appRoleId === appRoleId) || false;
 
   if (appRole) {
     return true;

--- a/src/servicePrincipalManager.ts
+++ b/src/servicePrincipalManager.ts
@@ -102,7 +102,7 @@ export async function getAppRoleId({
     (element: any) => element.displayName === displayName,
   );
 
-  console.log("App Role Id found:", appRole.id);
+  console.log("App Role Id for role:", displayName, "found:", appRole.id);
   return appRole.id;
 }
 
@@ -146,7 +146,7 @@ export async function isAppRoleAssignedToGroup({
   await errorHandler("Checking if app role is already assigned", result);
 
   const body = await result.json();
-  var appRole = body.value.find((element: any) => element.id === appRoleId);
+  var appRole = body.value.find((element: any) => element.appRoleId === appRoleId) || false;
 
   if (appRole) {
     return true;

--- a/src/servicePrincipalManager.ts
+++ b/src/servicePrincipalManager.ts
@@ -98,10 +98,11 @@ export async function getAppRoleId({
   await errorHandler("finding app role Id", result);
 
   const body = await result.json();
-  var appRole = body.find(
+  var appRole = body.value.find(
     (element: any) => element.displayName === displayName,
   );
 
+  console.log("App Role Id found:", appRole.id);
   return appRole.id;
 }
 

--- a/src/servicePrincipalManager.ts
+++ b/src/servicePrincipalManager.ts
@@ -146,14 +146,10 @@ export async function isAppRoleAssignedToGroup({
   await errorHandler("Checking if app role is already assigned", result);
 
   const body = await result.json();
-  var appRole =
+  const appRole =
     body.value.find((element: any) => element.appRoleId === appRoleId) || false;
 
-  if (appRole) {
-    return true;
-  } else {
-    return false;
-  }
+  return appRole;
 }
 
 async function assignRoleToGroup({


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15781


### Change description ###
Updating functions for role/group assignment to be more specific when searching for the base User group, this fixes a bug where a group having more than 1 role assigned caused a duplicate permission issue as the code searched for the first found.

Updating apps.yaml as the use case only appears when a group is a member of appRoleAssignment and an appRole which was not the case in the test file.
