### PR TITLE
DTSPO-16634 add a helper module finds app registrations by display name

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,18 @@ yarn test
 ### Releases
 
 Code pushed to the main branch is not published as a new release by default. Once your Pull Request has been merged, [draft a new release](https://github.com/hmcts/azure-app-proxy-manager/releases). Once the release is published a [Github Action](https://github.com/hmcts/azure-app-proxy-manager/actions/workflows/release.yaml) is triggered to push the latest version to NPM.
+
+### Helper modules
+
+#### Application Registrations Finder
+
+`applicationRegistrationsFinder` - This module used to find app registrations by their displayName.
+To run it you need to modify an constant  `applicationNames` in the `applicationRegistrationsFinder.ts` file, and then run the following commands:
+
+```bash
+yarn install
+yarn build
+yarn tsc -p .
+yarn node lib/applicationRegistrationsFinder.js
+```
+

--- a/src/applicationManager.ts
+++ b/src/applicationManager.ts
@@ -140,6 +140,7 @@ export async function findExistingApplication({
   token: string;
   displayName: string;
 }): Promise<string | undefined> {
+  // todo: call 'findApplicationsByName' from applicationRegistrations.js
   const result = await fetch(
     `https://graph.microsoft.com/v1.0/applications?$filter=displayName eq '${displayName}'&$top=1&$select=id`,
     {

--- a/src/applicationRegistrationsFinder.ts
+++ b/src/applicationRegistrationsFinder.ts
@@ -1,0 +1,23 @@
+// Azure authentication library to access Azure Key Vault
+import { DefaultAzureCredential } from "@azure/identity";
+
+import { findApplicationsByName } from "./helper/applicationRegistrations.js";
+
+// Azure SDK clients accept the credential as a parameter
+const credential = new DefaultAzureCredential();
+
+const { token } = await credential.getToken(
+  "https://graph.microsoft.com/.default",
+);
+let errors = false;
+
+// an array of application names (i.e prefixes) to search for
+const applicationNames = ["hmi"];
+// iterate over the array of application names and call the findAppRegistrationsByName function for each name
+for await (const applicationName of applicationNames) {
+  const applications = await findApplicationsByName(applicationName, token);
+  console.log(`found ${applicationName} appRegs `, applications.length);
+  applications.forEach((app: { id: string; displayName: string; publisherDomain: string; createdDateTime: string; }) => {
+    console.log(`${app.id}, ${app.displayName}, ${app.publisherDomain}, ${app.createdDateTime}`);
+  });
+}

--- a/src/helper/applicationRegistrations.ts
+++ b/src/helper/applicationRegistrations.ts
@@ -1,0 +1,22 @@
+import {errorHandler} from '../errorHandler.js';
+
+/*
+* This function finds applications by displayName
+* @param displayName - the display name of the application
+* @param token - the token to authenticate the request
+ */
+export async function findApplicationsByName(displayName: string, token: string) {
+  const url = `https://graph.microsoft.com/v1.0/applications?$filter=startswith(displayName, '${displayName}')&$count=true`;
+
+  const result = await fetch(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  await errorHandler("finding applications by displayName", result);
+
+  const body = await result.json();
+  return body.value;
+}


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-16634


### Change description ###
Add a helper module `applicationRegistrationsFinder.ts` that finds app registrations by display name

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)