### PR TITLE
Attempt fix to id not found error

### DIFF
--- a/src/servicePrincipalManager.ts
+++ b/src/servicePrincipalManager.ts
@@ -119,7 +119,10 @@ export async function getEntraGroupId(groupName: string, token: string) {
   await errorHandler("finding group id", result);
 
   const body = await result.json();
-  return body.value[0].id;
+  if (body.value.length === 1) {
+    return body.value[0].id;
+  }
+  return undefined;
 }
 
 export async function isAppRoleAssignedToGroup({


### PR DESCRIPTION
This is in place in a few other functions, maybe there is an issue where an id is not returned, this is not being handled properly currently by this function
Current error is:
```
TypeError: Cannot read properties of undefined (reading 'id')
    at getEntraGroupId (file:///tmp/xfs-b6d5b6c5/dlx-1738/.yarn/cache/azure-app-proxy-manager-npm-1.2.11-70f78853e3-e5d607ead2.zip/node_modules/azure-app-proxy-manager/lib/servicePrincipalManager.js:65:26)
```

For example: https://github.com/hmcts/azure-app-proxy-manager/blob/main/src/servicePrincipalManager.ts#L74-L77